### PR TITLE
更新问题

### DIFF
--- a/HelpSense/API/Events/CustomEventHandler.cs
+++ b/HelpSense/API/Events/CustomEventHandler.cs
@@ -332,7 +332,7 @@ namespace HelpSense.API.Events
             var players = ev.Players;
             var specialPlayers = ev.Players.ToList();
 
-            if (Wave is NtfSpawnWave)
+            if (Wave.Faction == Faction.FoundationStaff)
             {
                 Timing.CallDelayed(0.5f, () =>
                 {


### PR DESCRIPTION
该BUG会导致无法刷新特遣队 因为NTFSpawnWave始终不是RespawnWave