### PR TITLE
修复世纪遗留BUG

### DIFF
--- a/HelpSense/API/Events/CustomEventHandler.cs
+++ b/HelpSense/API/Events/CustomEventHandler.cs
@@ -96,6 +96,22 @@ namespace HelpSense.API.Events
         public static TranslateConfig TranslateConfig;
         public static SSSSTranslateConfig SSSSTranslateConfig;
         public static CommandTranslateConfig CommandTranslateConfig;
+        
+        public IEnumerator<float> Scp029InfEffect(Player player)
+        {
+            while(true)
+            {
+                yield return Timing.WaitForSeconds(1f);
+                if(!player.HasEffect<MovementBoost>())
+                    player.EnableEffect<MovementBoost>(20);
+                if (!player.HasEffect<Scp1853>())
+                    player.EnableEffect<Scp1853>(2);
+                if (!player.HasEffect<DamageReduction>())
+                    player.EnableEffect<DamageReduction>(15);
+                if (player.GetRoleName() != "SCP-029")
+                    yield break;
+            }
+        }
 
         public override void OnServerWaitingForPlayers()
         {
@@ -311,6 +327,7 @@ namespace HelpSense.API.Events
                         player.AddItem(ItemType.SCP268);
                         player.GetPlayerUi().CommonHint.ShowOtherHint(TranslateConfig.SCP029EscapeHint);
                     }
+                    Timing.RunCoroutine(Scp029InfEffect(player));
                 });
             }
             if (player.GetRoleName() == "SCP-703")

--- a/HelpSense/Handler/LobbyLocationHandler.cs
+++ b/HelpSense/Handler/LobbyLocationHandler.cs
@@ -14,12 +14,12 @@ namespace HelpSense.Handler
         {
             LobbyPosition = Random.Range(1, 6) switch
             {
-                1 => new Vector3(162.893f, 1019.470f, -13.430f),
-                2 => new Vector3(107.698f, 1014.048f, -12.555f),
-                3 => new Vector3(39.262f, 1014.112f, -31.844f),
-                4 => new Vector3(-15.854f, 1014.461f, -31.543f),
-                5 => new Vector3(130.483f, 993.366f, 20.601f),
-                _ => new Vector3(39.262f, 1014.112f, -31.844f),
+                1 => new Vector3(162.893f, 319.470f, -13.430f),
+                2 => new Vector3(107.698f, 314.048f, -12.555f),
+                3 => new Vector3(39.262f, 314.112f, -31.844f),
+                4 => new Vector3(-15.854f, 314.461f, -31.543f),
+                5 => new Vector3(130.483f, 293.366f, 20.601f),
+                _ => new Vector3(39.262f, 314.112f, -31.844f),
             };
         }
 
@@ -36,13 +36,13 @@ namespace HelpSense.Handler
 
         public static void MountainLocation()
         {
-            LobbyPosition = new Vector3(103.492f, 998.946f, 24.672f);
+            LobbyPosition = new Vector3(103.492f, 298.946f, 24.672f);
         }
 
         public static void ChaosLocation()
         {
-            LobbyPosition = new Vector3(-49.074f, 989.055f, -42.844f);
-            //LobbyPosition = new Vector3(-7.500f, 995.402f, -7.910f);
+            LobbyPosition = new Vector3(-49.074f, 289.055f, -42.844f);
+            //LobbyPosition = new Vector3(-7.500f, 295.402f, -7.910f);
         }
     }
 }


### PR DESCRIPTION
旧地表核心点(A电梯门口与A桥垂线交点)的y为1000，而新版本为300
但是该插件的等待大厅并未纠正，玩家会从天而降，所以需要修复

同时修复了SCP-029使用500而失去效果